### PR TITLE
Introduced check for specific webGL extension with new fallback

### DIFF
--- a/app/scripts/contrib/Cesium/CesiumView.js
+++ b/app/scripts/contrib/Cesium/CesiumView.js
@@ -929,7 +929,17 @@ define(['backbone.marionette',
 	            		that.activeCollections.push(obj.id);
 	            		if (settings[obj.id].band == 'F') {
 	            			that.features_collection[obj.id] = new Cesium.PointPrimitiveCollection();
-		            		
+
+	            			if(!that.map.scene.context._gl.getExtension('EXT_frag_depth')){
+	            				that.features_collection[obj.id]._rs = Cesium.RenderState.fromCache({
+		  						    depthTest : {
+		  						        enabled : true,
+		  						        func : Cesium.DepthFunction.LESS
+		  						    },
+		  						    depthMask : false,
+		  						    blending : Cesium.BlendingState.ALPHA_BLEND
+		  						});
+	            			}
 	            		}else if(
 	            			settings[obj.id].band == 'B_NEC' ||
 	            			settings[obj.id].band == 'SIFM' ||


### PR DESCRIPTION
As IE does not support EXT_frag_depth webGL extension i added a check to see if it is available. If not we use another render state configuration wich solves the issue of alpha adding up, but creates another issue of depth order of points.