### PR TITLE
Swapping F10.7 sources + addin MMA_SHA_2F

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -8,7 +8,8 @@ var VECTOR_PARAM = [
     "B_NEC", "v_SC", "SIFM", "IGRF12", "CHAOS-6-Combined", "Custom_Model",
     "B_NEC_resAC", "GPS_Position", "LEO_Position", "Relative_STEC_RMS", "Relative_STEC", "Absolute_STEC",
     "MCO_SHA_2C", "MCO_SHA_2D", "MCO_SHA_2F", "MLI_SHA_2C", "MLI_SHA_2D", 
-    "MMA_SHA_2C-Primary", "MMA_SHA_2C-Secondary", "MIO_SHA_2C-Primary", "MIO_SHA_2C-Secondary", "MIO_SHA_2D-Primary", "MIO_SHA_2D-Secondary"
+    "MMA_SHA_2C-Primary", "MMA_SHA_2C-Secondary", "MMA_SHA_2F-Primary", "MMA_SHA_2F-Secondary",
+    "MIO_SHA_2C-Primary", "MIO_SHA_2C-Secondary", "MIO_SHA_2D-Primary", "MIO_SHA_2D-Secondary"
 ]
 var VECTOR_BREAKDOWN = {
     'SIFM': ['B_N_res_SIFM','B_E_res_SIFM','B_C_res_SIFM'],
@@ -22,6 +23,8 @@ var VECTOR_BREAKDOWN = {
     'MLI_SHA_2D': ['B_N_res_MLI_SHA_2D','B_E_res_MLI_SHA_2D','B_C_res_MLI_SHA_2D'],
     'MMA_SHA_2C-Primary': ['B_N_res_MMA_SHA_2C-Primary','B_E_res_MMA_SHA_2C-Primary','B_C_res_MMA_SHA_2C-Primary'],
     'MMA_SHA_2C-Secondary': ['B_N_res_MMA_SHA_2C-Secondary','B_E_res_MMA_SHA_2C-Secondary','B_C_res_MMA_SHA_2C-Secondary'],
+    'MMA_SHA_2F-Primary': ['B_N_res_MMA_SHA_2F-Primary','B_E_res_MMA_SHA_2F-Primary','B_C_res_MMA_SHA_2F-Primary'],
+    'MMA_SHA_2F-Secondary': ['B_N_res_MMA_SHA_2F-Secondary','B_E_res_MMA_SHA_2F-Secondary','B_C_res_MMA_SHA_2F-Secondary'],
     'MIO_SHA_2C-Primary': ['B_N_res_MIO_SHA_2C-Primary','B_E_res_MIO_SHA_2C-Primary','B_C_res_MIO_SHA_2C-Primary'],
     'MIO_SHA_2C-Secondary': ['B_N_res_MIO_SHA_2C-Secondary','B_E_res_MIO_SHA_2C-Secondary','B_C_res_MIO_SHA_2C-Secondary'],
     'MIO_SHA_2D-Primary': ['B_N_res_MIO_SHA_2D-Primary','B_E_res_MIO_SHA_2D-Primary','B_C_res_MIO_SHA_2D-Primary'],
@@ -44,6 +47,8 @@ var VECTOR_BREAKDOWN = {
     'B_NEC_res_MLI_SHA_2D': ['B_N_res_MLI_SHA_2D','B_E_res_MLI_SHA_2D','B_C_res_MLI_SHA_2D'],
     'B_NEC_res_MMA_SHA_2C-Primary': ['B_N_res_MMA_SHA_2C-Primary','B_E_res_MMA_SHA_2C-Primary','B_C_res_MMA_SHA_2C-Primary'],
     'B_NEC_res_MMA_SHA_2C-Secondary': ['B_N_res_MMA_SHA_2C-Secondary','B_E_res_MMA_SHA_2C-Secondary','B_C_res_MMA_SHA_2C-Secondary'],
+    'B_NEC_res_MMA_SHA_2F-Primary': ['B_N_res_MMA_SHA_2F-Primary','B_E_res_MMA_SHA_2F-Primary','B_C_res_MMA_SHA_2F-Primary'],
+    'B_NEC_res_MMA_SHA_2F-Secondary': ['B_N_res_MMA_SHA_2F-Secondary','B_E_res_MMA_SHA_2F-Secondary','B_C_res_MMA_SHA_2F-Secondary'],
     'B_NEC_res_MIO_SHA_2C-Primary': ['B_N_res_MIO_SHA_2C-Primary','B_E_res_MIO_SHA_2C-Primary','B_C_res_MIO_SHA_2C-Primary'],
     'B_NEC_res_MIO_SHA_2C-Secondary': ['B_N_res_MIO_SHA_2C-Secondary','B_E_res_MIO_SHA_2C-Secondary','B_C_res_MIO_SHA_2C-Secondary'],
     'B_NEC_res_MIO_SHA_2D-Primary': ['B_N_res_MIO_SHA_2D-Primary','B_E_res_MIO_SHA_2D-Primary','B_C_res_MIO_SHA_2D-Primary'],

--- a/app/scripts/config.json
+++ b/app/scripts/config.json
@@ -3745,6 +3745,212 @@
             "differenceTo": null
 
         },{
+            "name": "MMA_SHA_2F-Primary",
+            "visible": false,
+            "timeSlider": true,
+            "timeSliderProtocol": "WPS",
+            "opacity": 0.7,
+            "tileSize":1024,
+            "validity":{
+                "start": "1900-01-01T00:00:00Z",
+                "end": "2020-01-01T00:00:00Z"
+            },
+            "views": [{
+                "id": "MMA_SHA_2F-Primary_view",
+                "protocol": "WMS",
+                "urls": [
+                    "http://localhost:9000/vires00/ows"
+                ],
+                "style": "default",
+                "format": "image/png"
+            }],
+            "download": {
+                "id": "MMA_SHA_2F-Primary",
+                "protocol": "EOWCS",
+                "url": "http://localhost:9000/vires00/ows"
+            },
+            "parameters": {
+                "F": {
+                    "range": [0, 80],
+                    "uom":"nT",
+                    "name": "Total field intensity",
+                    "colorscale": "jet",
+                    "selected": true
+                },
+                "H": {
+                    "range": [0, 60],
+                    "uom":"nT",
+                    "name": "Horizontal intensity",
+                    "colorscale": "jet"
+                },
+                "X": {
+                    "range": [-50, 30],
+                    "uom":"nT",
+                    "name": "North component",
+                    "colorscale": "diverging_1"
+                },
+                "Y": {
+                    "range": [-30, 50],
+                    "uom":"nT",
+                    "name": "East component",
+                    "colorscale": "diverging_1"
+                },
+                "Z": {
+                    "range": [-80, 50],
+                    "uom":"nT",
+                    "name": "Down component",
+                    "colorscale": "diverging_1"
+                },
+                "I": {
+                    "range": [-100, 100],
+                    "uom":"degree",
+                    "name": "Inclination",
+                    "colorscale": "diverging_1"
+                },
+                "D": {
+                    "range": [-200, 200],
+                    "uom":"degree",
+                    "name": "Declination",
+                    "colorscale": "diverging_1"
+                },
+                "X_EW": {
+                    "range": [-0.1, 0.1],
+                    "uom":"nT/km",
+                    "name": "North component (East-West Gradient)",
+                    "colorscale": "diverging_1"
+                },
+                "Y_EW": {
+                    "range": [-0.1, 0.1],
+                    "uom":"nT/km",
+                    "name": "East component (East-West Gradient)",
+                    "colorscale": "diverging_1"
+                },
+                "Z_EW": {
+                    "range": [-0.1, 0.1],
+                    "uom":"nT/km",
+                    "name": "Down component (East-West Gradient)",
+                    "colorscale": "diverging_1"
+                }
+            },
+            "download_parameters": {
+                "B_NEC_res_MMA_SHA_2F-Primary": {
+                    "uom":"nT",
+                    "name": "Residuals to MMA_SHA_2F-Primary model of Magnetic field vector, NEC frame"
+                },
+                "F_res_MMA_SHA_2F-Primary": {
+                    "uom":"nT",
+                    "name": "Residuals of Magnetic field intensity to MMA_SHA_2F-Primary model"
+                }
+            },
+            "height": 450,
+            "model": true,
+            "coefficients_range": [-1,-1],
+            "differenceTo": null
+
+        },{
+            "name": "MMA_SHA_2F-Secondary",
+            "visible": false,
+            "timeSlider": true,
+            "timeSliderProtocol": "WPS",
+            "opacity": 0.7,
+            "tileSize":1024,
+            "validity":{
+                "start": "1900-01-01T00:00:00Z",
+                "end": "2020-01-01T00:00:00Z"
+            },
+            "views": [{
+                "id": "MMA_SHA_2F-Secondary_view",
+                "protocol": "WMS",
+                "urls": [
+                    "http://localhost:9000/vires00/ows"
+                ],
+                "style": "default",
+                "format": "image/png"
+            }],
+            "download": {
+                "id": "MMA_SHA_2F-Secondary",
+                "protocol": "EOWCS",
+                "url": "http://localhost:9000/vires00/ows"
+            },
+            "parameters": {
+                "F": {
+                    "range": [0, 7],
+                    "uom":"nT",
+                    "name": "Total field intensity",
+                    "colorscale": "jet",
+                    "selected": true
+                },
+                "H": {
+                    "range": [0, 4.5],
+                    "uom":"nT",
+                    "name": "Horizontal intensity",
+                    "colorscale": "jet"
+                },
+                "X": {
+                    "range": [-4, 5],
+                    "uom":"nT",
+                    "name": "North component",
+                    "colorscale": "diverging_1"
+                },
+                "Y": {
+                    "range": [-3, 3],
+                    "uom":"nT",
+                    "name": "East component",
+                    "colorscale": "diverging_1"
+                },
+                "Z": {
+                    "range": [-7, 6],
+                    "uom":"nT",
+                    "name": "Down component",
+                    "colorscale": "diverging_1"
+                },
+                "I": {
+                    "range": [-100, 100],
+                    "uom":"degree",
+                    "name": "Inclination",
+                    "colorscale": "diverging_1"
+                },
+                "D": {
+                    "range": [-200, 200],
+                    "uom":"degree",
+                    "name": "Declination",
+                    "colorscale": "diverging_1"
+                },
+                "X_EW": {
+                    "range": [-0.004, 0.004],
+                    "uom":"nT/km",
+                    "name": "North component (East-West Gradient)",
+                    "colorscale": "diverging_1"
+                },
+                "Y_EW": {
+                    "range": [-0.005, 0.003],
+                    "uom":"nT/km",
+                    "name": "East component (East-West Gradient)",
+                    "colorscale": "diverging_1"
+                },
+                "Z_EW": {
+                    "range": [-0.0025, 0.002],
+                    "uom":"nT/km",
+                    "name": "Down component (East-West Gradient)",
+                    "colorscale": "diverging_1"
+                }
+            },
+            "download_parameters": {
+                "B_NEC_res_MMA_SHA_2F-Secondary": {
+                    "uom":"nT",
+                    "name": "Residuals to MMA_SHA_2F-Secondary model of Magnetic field vector, NEC frame"
+                },
+                "F_res_MMA_SHA_2F-Secondary": {
+                    "uom":"nT",
+                    "name": "Residuals of Magnetic field intensity to MMA_SHA_2F-Secondary model"
+                }
+            },
+            "height": 450,
+            "model": true,
+            "coefficients_range": [-1,-1],
+            "differenceTo": null
+
+        },{
             "name": "SIFM",
             "visible": false,
             "timeSlider": true,

--- a/app/scripts/contrib/AVViewer/AVView.js
+++ b/app/scripts/contrib/AVViewer/AVView.js
@@ -334,7 +334,7 @@ define(['backbone.marionette',
             this.sp.uom_set['QDLon'] = {uom: 'deg', name:'Quasi-Dipole Longitude'};
             this.sp.uom_set['Dst'] = {uom: null, name:'Disturbance storm time Index'};
             this.sp.uom_set['Kp'] = {uom: null, name:'Global geomagnetic storm Index'};
-            this.sp.uom_set['F10_INDEX'] = {uom: '1e-22 J/s/m^2/Hz', name:'10.7cm Solar Radio Flux'};
+            this.sp.uom_set['F107'] = {uom: '1e-22 J/s/m^2/Hz', name:'Observed 10.7cm Solar Radio Flux'};
             this.sp.uom_set['OrbitNumber'] = {uom: null, name:'Orbit number'};
 
             globals.swarm.set('uom_set', this.sp.uom_set);

--- a/app/scripts/controller/DataController.js
+++ b/app/scripts/controller/DataController.js
@@ -291,6 +291,8 @@
             "F_res_MLI_SHA_2D", "B_NEC_res_MLI_SHA_2D",
             "F_res_MMA_SHA_2C-Primary", "B_NEC_res_MMA_SHA_2C-Primary",
             "F_res_MMA_SHA_2C-Secondary", "B_NEC_res_MMA_SHA_2C-Secondary",
+            "F_res_MMA_SHA_2F-Primary", "B_NEC_res_MMA_SHA_2F-Primary",
+            "F_res_MMA_SHA_2F-Secondary", "B_NEC_res_MMA_SHA_2F-Secondary",
             "F_res_MIO_SHA_2C-Primary", "B_NEC_res_MIO_SHA_2C-Primary",
             "F_res_MIO_SHA_2C-Secondary", "B_NEC_res_MIO_SHA_2C-Secondary",
             "F_res_MIO_SHA_2D-Primary", "B_NEC_res_MIO_SHA_2D-Primary",

--- a/app/scripts/controller/DataController.js
+++ b/app/scripts/controller/DataController.js
@@ -275,7 +275,7 @@
           
           var variables = [
             "F", "F_error", "B_NEC_resAC", "B_VFM", "B_error", "B_NEC", "n", "T_elec", "U_SC",
-            "v_SC", "Bubble_Probability", "Kp", "Dst", "QDLat", "QDLon", "MLT",
+            "v_SC", "Bubble_Probability", "Kp", "Dst", "F107", "QDLat", "QDLon", "MLT",
             "B_NEC_res_IGRF12","B_NEC_res_SIFM","B_NEC_res_CHAOS-6-Combined",
             "B_NEC_res_Custom_Model", "F_res_IGRF12","F_res_SIFM",
             "F_res_CHAOS-6-Combined", "F_res_Custom_Model",
@@ -283,7 +283,6 @@
             "IRC", "IRC_Error", "FAC", "FAC_Error",
             "EEF", "RelErr", "OrbitNumber",
             "SunDeclination","SunRightAscension","SunHourAngle","SunAzimuthAngle","SunZenithAngle",
-            "F10_INDEX",
             // New models
             "F_res_MCO_SHA_2C", "B_NEC_res_MCO_SHA_2C",
             "F_res_MCO_SHA_2D", "B_NEC_res_MCO_SHA_2D",

--- a/app/templates/Info.hbs
+++ b/app/templates/Info.hbs
@@ -68,6 +68,9 @@
             <li style="list-style-type: circle;"> 
               Spherical harmonic model of the large-scale magnetospheric field and its Earth-induced counterpart (<a target="_blank" href="https://earth.esa.int/web/guest/missions/esa-eo-missions/swarm/data-handbook/level-2-product-definitions#MMA_SHA_2C">MMA_SHA_2C-Primary &amp; MMA_SHA_2C-Secondary Field</a>)
             </li>
+            <li style="list-style-type: circle;">
+              Spherical harmonic model of the large-scale magnetospheric field and its Earth-induced counterpart (<a target="_blank" href="https://earth.esa.int/web/guest/missions/esa-eo-missions/swarm/data-handbook/level-2-product-definitions#MMA_SHA_2F">MMA_SHA_2F-Primary &amp; MMA_SHA_2F-Secondary Field</a>)
+            </li>
           </ul>
           <p>The following Spherical Harmonic Models of the Daily Geomagnetic Variation are available:</p>
           <ul>


### PR DESCRIPTION
This is catch-up client PR to expose new features already earlier deployed on the server.

Key features:
- swapping the sources of the F10.7 index displayed by the client. The client now displays the desired observed F10.7 provided by `AUX_F10_2_` instead of the adjusted F10.7 provided by `AUX_IMF_2_`.
- exposing the `MMA_SHA_2F` model.
