### PR TITLE
Basic support for the TEC Asolute_VTEC and Elevation_Angle (corrected)

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -6,7 +6,8 @@ var SCALAR_PARAM = [
 
 var VECTOR_PARAM = [
     "B_NEC", "SIFM", "IGRF12", "CHAOS-6-Combined", "Custom_Model",
-    "B_NEC_resAC", "GPS_Position", "LEO_Position", "Relative_STEC_RMS", "Relative_STEC", "Absolute_STEC",
+    "B_NEC_resAC", "GPS_Position", "LEO_Position",
+    "Relative_STEC_RMS", "Relative_STEC", "Absolute_STEC", "Absolute_VTEC", "Elevation_Angle",
     "MCO_SHA_2C", "MCO_SHA_2D", "MCO_SHA_2F", "MLI_SHA_2C", "MLI_SHA_2D", 
     "MMA_SHA_2C-Primary", "MMA_SHA_2C-Secondary", "MMA_SHA_2F-Primary", "MMA_SHA_2F-Secondary",
     "CHAOS-6-MMA-Primary", "CHAOS-6-MMA-Secondary",

--- a/app/scripts/config.json
+++ b/app/scripts/config.json
@@ -1057,6 +1057,20 @@
                     "uom":"TECU",
                     "colorscale": "portland",
                     "name": "Relative STEC RMS"
+                },
+                "Absolute_VTEC": {
+                    "range": [0, 35],
+                    "uom":"TECU",
+                    "colorscale": "plasma",
+                    "selected": true,
+                    "name": "Absolute vertical TEC"
+                },
+                "Elevation_Angle": {
+                    "range": [0, 90],
+                    "uom":"degree",
+                    "colorscale": "plasma",
+                    "selected": true,
+                    "name": "Elevation Angle"
                 }
             },
             "download_parameters": {
@@ -1115,6 +1129,14 @@
                 "Absolute_STEC": {
                     "uom": "TECU",
                     "name": "Absolute slant TEC"
+                },
+                "Absolute_VTEC": {
+                    "uom": "TECU",
+                    "name": "Absolute vertical TEC"
+                },
+                "Elevation_Angle": {
+                    "uom": "degree",
+                    "name": "Elevation Angle"
                 },
                 "Relative_STEC": {
                     "uom": "TECU",
@@ -1201,6 +1223,20 @@
                     "uom":"TECU",
                     "colorscale": "portland",
                     "name": "Relative STEC RMS"
+                },
+                "Absolute_VTEC": {
+                    "range": [0, 35],
+                    "uom":"TECU",
+                    "colorscale": "plasma",
+                    "selected": true,
+                    "name": "Absolute vertical TEC"
+                },
+                "Elevation_Angle": {
+                    "range": [0, 90],
+                    "uom":"degree",
+                    "colorscale": "plasma",
+                    "selected": true,
+                    "name": "Elevation Angle"
                 }
             },
             "download_parameters": {
@@ -1259,6 +1295,14 @@
                 "Absolute_STEC": {
                     "uom": "TECU",
                     "name": "Absolute slant TEC"
+                },
+                "Absolute_VTEC": {
+                    "uom": "TECU",
+                    "name": "Absolute vertical TEC"
+                },
+                "Elevation_Angle": {
+                    "uom": "degree",
+                    "name": "Elevation Angle"
                 },
                 "Relative_STEC": {
                     "uom": "TECU",
@@ -1345,6 +1389,20 @@
                     "uom":"TECU",
                     "colorscale": "portland",
                     "name": "Relative STEC RMS"
+                },
+                "Absolute_VTEC": {
+                    "range": [0, 35],
+                    "uom":"TECU",
+                    "colorscale": "plasma",
+                    "selected": true,
+                    "name": "Absolute vertical TEC"
+                },
+                "Elevation_Angle": {
+                    "range": [0, 90],
+                    "uom":"degree",
+                    "colorscale": "plasma",
+                    "selected": true,
+                    "name": "Elevation Angle"
                 }
             },
             "download_parameters": {
@@ -1403,6 +1461,14 @@
                 "Absolute_STEC": {
                     "uom": "TECU",
                     "name": "Absolute slant TEC"
+                },
+                "Absolute_VTEC": {
+                    "uom": "TECU",
+                    "name": "Absolute vertical TEC"
+                },
+                "Elevation_Angle": {
+                    "uom": "degree",
+                    "name": "Elevation Angle"
                 },
                 "Relative_STEC": {
                     "uom": "TECU",

--- a/app/scripts/config.json
+++ b/app/scripts/config.json
@@ -1062,14 +1062,12 @@
                     "range": [0, 35],
                     "uom":"TECU",
                     "colorscale": "plasma",
-                    "selected": true,
                     "name": "Absolute vertical TEC"
                 },
                 "Elevation_Angle": {
                     "range": [0, 90],
                     "uom":"degree",
                     "colorscale": "plasma",
-                    "selected": true,
                     "name": "Elevation Angle"
                 }
             },
@@ -1228,14 +1226,12 @@
                     "range": [0, 35],
                     "uom":"TECU",
                     "colorscale": "plasma",
-                    "selected": true,
                     "name": "Absolute vertical TEC"
                 },
                 "Elevation_Angle": {
                     "range": [0, 90],
                     "uom":"degree",
                     "colorscale": "plasma",
-                    "selected": true,
                     "name": "Elevation Angle"
                 }
             },
@@ -1394,14 +1390,12 @@
                     "range": [0, 35],
                     "uom":"TECU",
                     "colorscale": "plasma",
-                    "selected": true,
                     "name": "Absolute vertical TEC"
                 },
                 "Elevation_Angle": {
                     "range": [0, 90],
                     "uom":"degree",
                     "colorscale": "plasma",
-                    "selected": true,
                     "name": "Elevation Angle"
                 }
             },

--- a/app/scripts/contrib/AVViewer/AVView.js
+++ b/app/scripts/contrib/AVViewer/AVView.js
@@ -532,6 +532,7 @@ define(['backbone.marionette',
                         var filterstouse = [
                             'Ne', 'Te', 'Bubble_Probability',
                             'Relative_STEC_RMS', 'Relative_STEC', 'Absolute_STEC',
+                            'Absolute_VTEC', 'Elevation_Angle',
                             'IRC', 'FAC',
                             'EEF'
                         ];
@@ -592,7 +593,8 @@ define(['backbone.marionette',
                         // If previous does not contain key data and new one
                         // does we add key parameter to selection in plot
                         var parasToCheck = [
-                            'Ne', 'F', 'Bubble_Probability', 'Absolute_STEC', 'FAC', 'EEF'
+                            'Ne', 'F', 'Bubble_Probability', 'Absolute_STEC',
+                            'Absolute_VTEC', 'Elevation_Angle', 'FAC', 'EEF'
                         ];
 
                         // Check if y axis parameters are still available

--- a/app/scripts/contrib/Cesium/CesiumView.js
+++ b/app/scripts/contrib/Cesium/CesiumView.js
@@ -1141,6 +1141,8 @@ define([
                                     })) {
 
                                     if(tovisualize[i] === 'Absolute_STEC' ||
+                                       tovisualize[i] === 'Absolute_VTEC' ||
+                                       tovisualize[i] === 'Elevation_Angle' ||
                                        tovisualize[i] === 'Relative_STEC' ||
                                        tovisualize[i] === 'Relative_STEC_RMS'){
                                         if(lastTS === null){

--- a/app/scripts/controller/DataController.js
+++ b/app/scripts/controller/DataController.js
@@ -274,7 +274,7 @@
             "B_NEC_res_IGRF12","B_NEC_res_SIFM","B_NEC_res_CHAOS-6-Combined",
             "B_NEC_res_Custom_Model", "F_res_IGRF12","F_res_SIFM",
             "F_res_CHAOS-6-Combined", "F_res_Custom_Model",
-            "Relative_STEC_RMS", "Relative_STEC", "Absolute_STEC", "GPS_Position", "LEO_Position",
+            "Relative_STEC_RMS", "Relative_STEC", "Absolute_STEC", "Absolute_VTEC", "Elevation_Angle", "GPS_Position", "LEO_Position",
             "IRC", "IRC_Error", "FAC", "FAC_Error",
             "EEF", "RelErr", "OrbitNumber",
             "SunDeclination","SunRightAscension","SunHourAngle","SunAzimuthAngle","SunZenithAngle",


### PR DESCRIPTION
This PR adds basic support for the TEC products `Absolute_VTEC` and `Elevation_Angle` variables. (https://github.com/ESA-VirES/WebClient-Framework/issues/283)