### PR TITLE
Add pole view functionality

### DIFF
--- a/app/scripts/contrib/Cesium/CesiumView.js
+++ b/app/scripts/contrib/Cesium/CesiumView.js
@@ -139,11 +139,11 @@ define([
             this.$el.append('<div id="poleViewDiv"></div>')
             $('#poleViewDiv').append('<button class="btn btn-success darkbutton dropdown-toggle" title="Pole View Selection" id="poleViewButton" data-toggle="dropdown">Globe View</button>');
             $('#poleViewDiv').append('<ul id="poleViewUl" class="dropdown-menu"></ul>');
-            $('#poleViewUl').append('<li><button class="btn btn-success darkbutton magN poleButton">Mag. North</button></li>');
-            $('#poleViewUl').append('<li><button class="btn btn-success darkbutton magS poleButton">Mag. South</button></li>');
-            $('#poleViewUl').append('<li><button class="btn btn-success darkbutton geoN poleButton">Geo. North</button></li>');
-            $('#poleViewUl').append('<li><button class="btn btn-success darkbutton geoS poleButton">Geo. South</button></li>');
-            $('#poleViewUl').append('<li><button class="btn btn-success darkbutton poleButton" id="resetCameraView">Reset View</button></li>');
+            $('#poleViewUl').append('<li><button class="btn btn-success darkbutton magN poleButton" title="Magnetic North Pole">Mag. North</button></li>');
+            $('#poleViewUl').append('<li><button class="btn btn-success darkbutton magS poleButton" title="Magnetic South Pole">Mag. South</button></li>');
+            $('#poleViewUl').append('<li><button class="btn btn-success darkbutton geoN poleButton" title="Geographic North Pole">Geo. North</button></li>');
+            $('#poleViewUl').append('<li><button class="btn btn-success darkbutton geoS poleButton" title="Geographic South Pole">Geo. South</button></li>');
+            $('#poleViewUl').append('<li><button class="btn btn-success darkbutton poleButton" id="resetCameraView" title="Reset to the free Globe View.">Reset View</button></li>');
 
             this.bindPolarButtons();
 

--- a/app/scripts/contrib/Cesium/CesiumView.js
+++ b/app/scripts/contrib/Cesium/CesiumView.js
@@ -137,7 +137,7 @@ define([
             this.$el.append('<div type="button" class="btn btn-success darkbutton"  id="bb_selection">Select Area</div>');
 
             this.$el.append('<div id="poleViewDiv"></div>')
-            $('#poleViewDiv').append('<button class="btn btn-success darkbutton dropdown-toggle" id="poleViewButton" data-toggle="dropdown">Globe View</button>');
+            $('#poleViewDiv').append('<button class="btn btn-success darkbutton dropdown-toggle" title="Pole View Selection" id="poleViewButton" data-toggle="dropdown">Globe View</button>');
             $('#poleViewDiv').append('<ul id="poleViewUl" class="dropdown-menu"></ul>');
             $('#poleViewUl').append('<li><button class="btn btn-success darkbutton magN poleButton">Mag. North</button></li>');
             $('#poleViewUl').append('<li><button class="btn btn-success darkbutton magS poleButton">Mag. South</button></li>');

--- a/app/scripts/contrib/Cesium/CesiumView.js
+++ b/app/scripts/contrib/Cesium/CesiumView.js
@@ -139,11 +139,11 @@ define([
             this.$el.append('<div id="poleViewDiv"></div>')
             $('#poleViewDiv').append('<button class="btn btn-success darkbutton dropdown-toggle" id="poleViewButton" data-toggle="dropdown">Globe View</button>');
             $('#poleViewDiv').append('<ul id="poleViewUl" class="dropdown-menu"></ul>');
-            $('#poleViewUl').append('<li><button class="btn btn-success darkbutton magN poleButton">Mag N</button></li>');
-            $('#poleViewUl').append('<li><button class="btn btn-success darkbutton magS poleButton">Mag S</button></li>');
-            $('#poleViewUl').append('<li><button class="btn btn-success darkbutton geoN poleButton">Geo N</button></li>');
-            $('#poleViewUl').append('<li><button class="btn btn-success darkbutton geoS poleButton">Geo S</button></li>');
-            $('#poleViewUl').append('<li><button class="btn btn-success darkbutton" id="resetCameraView">Reset Cam</button></li>');
+            $('#poleViewUl').append('<li><button class="btn btn-success darkbutton magN poleButton">Mag. North</button></li>');
+            $('#poleViewUl').append('<li><button class="btn btn-success darkbutton magS poleButton">Mag. South</button></li>');
+            $('#poleViewUl').append('<li><button class="btn btn-success darkbutton geoN poleButton">Geo. North</button></li>');
+            $('#poleViewUl').append('<li><button class="btn btn-success darkbutton geoS poleButton">Geo. South</button></li>');
+            $('#poleViewUl').append('<li><button class="btn btn-success darkbutton poleButton" id="resetCameraView">Reset View</button></li>');
 
             this.bindPolarButtons();
 
@@ -2347,7 +2347,6 @@ define([
         },
 
         polarViewZoom: function(){
-            $("#poleViewButton").text('Polar View');
             $(".poleButton").removeClass("viewActive");
             $("#poleViewButton").addClass("viewActive");
             this.map.scene.screenSpaceCameraController.enableRotate = false;
@@ -2375,7 +2374,7 @@ define([
         },
 
         bindPolarButtons: function() {
-            $('.poleButton, #resetCameraView').off('click');
+            $('.poleButton').off('click');
             // magnetic poles hardcoded as were in 1.1.2015 (igrf)
             $(".magN").click(function(){
                 this.map.scene.camera.flyTo({
@@ -2386,6 +2385,7 @@ define([
                     },
                     complete : function(){
                         this.polarViewZoom();
+                        $('#poleViewButton').text('Mag. North');
                         $(".magN").addClass("viewActive");
                     }.bind(this)
                 });
@@ -2401,6 +2401,7 @@ define([
                     },
                     complete : function(){
                         this.polarViewZoom();
+                        $('#poleViewButton').text('Mag. South');
                         $(".magS").addClass("viewActive");
                     }.bind(this)
                 });
@@ -2411,6 +2412,7 @@ define([
                     destination : Cesium.Cartesian3.fromDegrees(0, 90, 10000000),
                     complete : function(){
                         this.polarViewZoom();
+                        $('#poleViewButton').text('Geo. North');
                         $(".geoN").addClass("viewActive");
                     }.bind(this)
                 });
@@ -2421,6 +2423,7 @@ define([
                     destination : Cesium.Cartesian3.fromDegrees(0, -90, 10000000),
                     complete : function(){
                         this.polarViewZoom();
+                        $('#poleViewButton').text('Geo. South');
                         $(".geoS").addClass("viewActive");
                     }.bind(this)
                 });

--- a/app/scripts/contrib/Cesium/CesiumView.js
+++ b/app/scripts/contrib/Cesium/CesiumView.js
@@ -248,10 +248,13 @@ define([
                 container: $('.cesium-viewer-toolbar')[0]
             });
 
-            this.map.scene.morphStart.addEventListener(function(evt){
+            this.map.scene.morphStart.addEventListener(function(){
+                this.globalViewZoomReset();
+            }.bind(this));
+
+            this.map.scene.morphComplete.addEventListener(function(){
                 // change of mode event handler
                 if (this.map._sceneModePicker.viewModel.sceneMode !== 3){
-                    this.globalViewZoomReset();
                     $('#poleViewDiv').addClass("hidden");
                 } else{
                     $('#poleViewDiv').removeClass("hidden");
@@ -571,6 +574,7 @@ define([
             if(this.map._sceneModePicker){
                 var container = this.map._sceneModePicker.container;
                 var scene = this.map._sceneModePicker.viewModel._scene;
+                this.map._sceneModePicker.destroy();
                 var modepicker = new Cesium.SceneModePicker(container, scene);
                 this.map._sceneModePicker = modepicker;
             }

--- a/app/scripts/contrib/Cesium/CesiumView.js
+++ b/app/scripts/contrib/Cesium/CesiumView.js
@@ -574,7 +574,6 @@ define([
             if(this.map._sceneModePicker){
                 var container = this.map._sceneModePicker.container;
                 var scene = this.map._sceneModePicker.viewModel._scene;
-                this.map._sceneModePicker.destroy();
                 var modepicker = new Cesium.SceneModePicker(container, scene);
                 this.map._sceneModePicker = modepicker;
             }

--- a/app/styles/cesium.scss
+++ b/app/styles/cesium.scss
@@ -176,3 +176,7 @@
   margin: 4px;
   text-align: center;
 }
+
+.poleButton{
+  padding: 4px 8px!important;
+}

--- a/app/styles/cesium.scss
+++ b/app/styles/cesium.scss
@@ -119,7 +119,7 @@
   border-color: #444 !important;
 }
 
-.darkbutton:hover{
+.darkbutton:hover, .darkbutton.viewActive{
   background-color: #48b !important;
   border-color: #aef !important;
 }
@@ -153,4 +153,26 @@
   padding-left: 3px;
   padding-right: 3px;
   font-family: monospace;
+}
+
+#poleViewDiv{
+  position: absolute;
+  right: 336px;
+  top: 7px;
+  z-index: 5;
+}
+
+#poleViewButton{
+  height: 32px;
+  width: 98px;
+}
+
+#poleViewUl{
+  min-width: 90px;
+  padding: 0;
+}
+
+#poleViewUl li {
+  margin: 4px;
+  text-align: center;
 }


### PR DESCRIPTION
- Created buttons and functionality enabling zoom to magnetic and geographic poles
- Poles and camera rotations are computed according to IGRF in 1.1.2015
- Usable only in 3D view
- This sets up polar view mode, where only zooming to/from the given pole is possible, all other globe moving/rotation operations are disabled
- Reset Cam button sets the view to default and re-enables globe operations