### PR TITLE
CHAOS-6 to CHAOS-7 transition

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -309,7 +309,12 @@ var MASTER_PRIORITY = [
                                 // where necessary
                             }
                             if (pC[prodId].hasOwnProperty('components')) {
-                                product.components = pC[prodId].components;
+                                // translate renamed models
+                                product.components = _.map(pC[prodId].components, function (component) {
+                                    var table = config.magneticModels.modelIdTranslation || {};
+                                    component.id = table[component.id] || component.id;
+                                    return component;
+                                });
                             }
                         }
 

--- a/app/scripts/config.json
+++ b/app/scripts/config.json
@@ -23,14 +23,38 @@
             {"id": "MCO_SHA_2D"},
             {"id": "MLI_SHA_2C"},
             {"id": "MLI_SHA_2D"},
-            {"id": "MIO_SHA_2C-Primary"},
-            {"id": "MIO_SHA_2C-Secondary"},
-            {"id": "MIO_SHA_2D-Primary"},
-            {"id": "MIO_SHA_2D-Secondary"},
-            {"id": "MMA_SHA_2C-Primary"},
-            {"id": "MMA_SHA_2C-Secondary"},
-            {"id": "MMA_SHA_2F-Primary"},
-            {"id": "MMA_SHA_2F-Secondary"},
+            {
+                "id": "MIO_SHA_2C-Primary",
+                "name": "MIO_SHA_2C Primary"
+            },
+            {
+                "id": "MIO_SHA_2C-Secondary",
+                "name": "MIO_SHA_2C Secondary"
+            },
+            {
+                "id": "MIO_SHA_2D-Primary",
+                "name": "MIO_SHA_2D Primary"
+            },
+            {
+                "id": "MIO_SHA_2D-Secondary",
+                "name": "MIO_SHA_2D Secondary"
+            },
+            {
+                "id": "MMA_SHA_2C-Primary",
+                "name": "MMA_SHA_2C Primary"
+            },
+            {
+                "id": "MMA_SHA_2C-Secondary",
+                "name": "MMA_SHA_2C Secondary"
+            },
+            {
+                "id": "MMA_SHA_2F-Primary",
+                "name": "MMA_SHA_2F Primary"
+            },
+            {
+                "id": "MMA_SHA_2F-Secondary",
+                "name": "MMA_SHA_2F Secondary"
+            },
             {"id": "IGRF12"},
             {"id": "LCS-1"},
             {"id": "MF7"},

--- a/app/scripts/config.json
+++ b/app/scripts/config.json
@@ -34,13 +34,22 @@
             {"id": "IGRF12"},
             {"id": "LCS-1"},
             {"id": "MF7"},
-            {"id": "CHAOS-6-Core"},
             {
-                "id": "CHAOS-6-Static",
-                "name": "CHAOS-6-Crust"
+                "id": "CHAOS-Core",
+                "name": "CHAOS-7 Core"
             },
-            {"id": "CHAOS-6-MMA-Primary"},
-            {"id": "CHAOS-6-MMA-Secondary"},
+            {
+                "id": "CHAOS-Static",
+                "name": "CHAOS-7 Crust"
+            },
+            {
+                "id": "CHAOS-MMA-Primary",
+                "name": "CHAOS-MMA Primary"
+            },
+            {
+                "id": "CHAOS-MMA-Secondary",
+                "name": "CHAOS-MMA Secondary"
+            },
             {
                 "id": "Custom_Model",
                 "name": "Custom Model",

--- a/app/scripts/config.json
+++ b/app/scripts/config.json
@@ -79,7 +79,13 @@
                 "name": "Custom Model",
                 "isCustomModel": true
             }
-        ]
+        ],
+        "modelIdTranslation": {
+            "CHAOS-6-Core": "CHAOS-Core",
+            "CHAOS-6-Static": "CHAOS-Static",
+            "CHAOS-6-MMA-Primary": "CHAOS-MMA-Primary",
+            "CHAOS-6-MMA-Secondary": "CHAOS-MMA-Secondary"
+        }
     },
 
     "mapConfig": {

--- a/app/scripts/config.json
+++ b/app/scripts/config.json
@@ -3976,7 +3976,7 @@
             "components": [
                 {
                     "sign": "+",
-                    "id": "CHAOS-6-Core",
+                    "id": "CHAOS-Core",
                     "parameters": {}
                 }
             ]

--- a/app/scripts/util.js
+++ b/app/scripts/util.js
@@ -29,9 +29,9 @@ var getISODateTimeString = function (date, truncateMiliseconds) {
   return getISODateString(date)
     + padLeft(String(date.getUTCHours()), "0", 2) + ":"
     + padLeft(String(date.getUTCMinutes()), "0", 2) + ":"
-    + padLeft(String(date.getUTCSeconds()), "0", 2) + (
-      truncateMiliseconds ? "" : ("." + padLeft(String(date.getUTCMilliseconds()), "0", 3))
-    ) + "Z";
+    + padLeft(String(date.getUTCSeconds()), "0", 2)
+    + (truncateMiliseconds ? "" : ("." + padLeft(String(date.getUTCMilliseconds()), "0", 3)))
+    + "Z";
 };
 
 var getISOTimeString = function (date) {
@@ -229,9 +229,7 @@ var saveProductStatus = function (product) {
 
   prevConf[prdId] = prod;
 
-  localStorage.setItem(
-    'productsConfiguration', JSON.stringify(prevConf)
-  );
+  localStorage.setItem('productsConfiguration', JSON.stringify(prevConf));
 };
 
 
@@ -269,8 +267,5 @@ var savePrameterStatus = function (globals) {
     }
   }
   // Save parameter style changes
-  localStorage.setItem(
-    'parameterConfiguration',
-    JSON.stringify(parConf)
-  );
+  localStorage.setItem('parameterConfiguration', JSON.stringify(parConf));
 };

--- a/app/templates/Info.hbs
+++ b/app/templates/Info.hbs
@@ -43,7 +43,7 @@
               The 12th Generation International Geomagnetic Reference Field (<a target="_blank" href="http://earth-planets-space.springeropen.com/articles/10.1186/s40623-015-0228-9">IGRF 12</a>) released in 2015 by the International Association of Geomagnetism and Aeronomy
             </li>
             <li style="list-style-type: circle;">
-              The CHAOS-6 high resolution geomagnetic field model, derived primarily from Swarm, CHAMP, and Ørsted satellite magnetic data along with ground observatory data (<a target="_blank" href="http://www.spacecenter.dk/files/magnetic-models/CHAOS-6/">CHAOS-6</a>)
+              The CHAOS-7 high resolution geomagnetic field model derived from Swarm, CHAMP, Ørsted, SAC-C and Cryosat satellite magnetic data along with ground observatory data (<a target="_blank" href="http://www.spacecenter.dk/files/magnetic-models/CHAOS-7/">CHAOS-7</a>)
             </li>
             <li style="list-style-type: circle;">
               The LCS-1 high-resolution lithospheric field model, derived from CHAMP and Swarm satellite observations (<a target="_blank" href="http://www.spacecenter.dk/files/magnetic-models/LCS-1/">LCS-1</a>)
@@ -79,7 +79,7 @@
               Spherical harmonic model of the large-scale magnetospheric field and its Earth-induced counterpart (<a target="_blank" href="https://earth.esa.int/web/guest/missions/esa-eo-missions/swarm/data-handbook/level-2-product-definitions#MMA_SHA_2F">MMA_SHA_2F-Primary &amp; MMA_SHA_2F-Secondary Field</a>)
             </li>
             <li style="list-style-type: circle;">
-              The <a target="_blank" href="http://www.spacecenter.dk/files/magnetic-models/CHAOS-6/">CHAOS-6</a> spherical harmonic model of the large-scale magnetospheric field and its Earth-induced counterpart (CHAOS-6-MMA-Primary &amp; CHAOS-6-MMA-Secondary Field)
+              The <a target="_blank" href="http://www.spacecenter.dk/files/magnetic-models/CHAOS-7/">CHAOS</a> spherical harmonic model of the large-scale magnetospheric field and its Earth-induced counterpart (CHAOS-MMA primary and secondary fields)
             </li>
           </ul>
           <p>The following Spherical Harmonic Models of the Daily Geomagnetic Variation are available:</p>

--- a/app/templates/Info.hbs
+++ b/app/templates/Info.hbs
@@ -73,22 +73,22 @@
           <p>The following Spherical Harmonic Models of the Magnetospheric Field are available:</p>
           <ul>
             <li style="list-style-type: circle;">
-              Spherical harmonic model of the large-scale magnetospheric field and its Earth-induced counterpart (<a target="_blank" href="https://earth.esa.int/web/guest/missions/esa-eo-missions/swarm/data-handbook/level-2-product-definitions#MMA_SHA_2C">MMA_SHA_2C-Primary &amp; MMA_SHA_2C-Secondary Field</a>)
+              Spherical harmonic model of the large-scale magnetospheric field and its Earth-induced counterpart (<a target="_blank" href="https://earth.esa.int/web/guest/missions/esa-eo-missions/swarm/data-handbook/level-2-product-definitions#MMA_SHA_2C">MMA_SHA_2C primary and secondary field</a>)
             </li>
             <li style="list-style-type: circle;">
-              Spherical harmonic model of the large-scale magnetospheric field and its Earth-induced counterpart (<a target="_blank" href="https://earth.esa.int/web/guest/missions/esa-eo-missions/swarm/data-handbook/level-2-product-definitions#MMA_SHA_2F">MMA_SHA_2F-Primary &amp; MMA_SHA_2F-Secondary Field</a>)
+              Spherical harmonic model of the large-scale magnetospheric field and its Earth-induced counterpart (<a target="_blank" href="https://earth.esa.int/web/guest/missions/esa-eo-missions/swarm/data-handbook/level-2-product-definitions#MMA_SHA_2F">MMA_SHA_2F primary and secondary field</a>)
             </li>
             <li style="list-style-type: circle;">
-              The <a target="_blank" href="http://www.spacecenter.dk/files/magnetic-models/CHAOS-7/">CHAOS</a> spherical harmonic model of the large-scale magnetospheric field and its Earth-induced counterpart (CHAOS-MMA primary and secondary fields)
+              The <a target="_blank" href="http://www.spacecenter.dk/files/magnetic-models/CHAOS-7/">CHAOS</a> spherical harmonic model of the large-scale magnetospheric field and its Earth-induced counterpart (CHAOS-MMA primary and secondary field)
             </li>
           </ul>
           <p>The following Spherical Harmonic Models of the Daily Geomagnetic Variation are available:</p>
           <ul>
             <li style="list-style-type: circle;">
-              Spherical harmonic model of the daily geomagnetic variation at middle latitudes (Sq) and low latitudes (EEJ) (<a target="_blank" href="https://earth.esa.int/web/guest/missions/esa-eo-missions/swarm/data-handbook/level-2-product-definitions#MIO_SHA_2C">MIO_SHA_2C-Primary &amp; MIO_SHA_2C-Secondary Field</a>)
+              Spherical harmonic model of the daily geomagnetic variation at middle latitudes (Sq) and low latitudes (EEJ) (<a target="_blank" href="https://earth.esa.int/web/guest/missions/esa-eo-missions/swarm/data-handbook/level-2-product-definitions#MIO_SHA_2C">MIO_SHA_2C primary and secondary field</a>)
             </li>
             <li style="list-style-type: circle;">
-              Spherical harmonic model of the daily geomagnetic variation at middle latitudes (Sq) and low latitudes (EEJ) (<a target="_blank" href="https://earth.esa.int/web/guest/missions/esa-eo-missions/swarm/data-handbook/level-2-product-definitions#MIO_SHA_2D">MIO_SHA_2D-Primary &amp; MIO_SHA_2D-Secondary Field</a>)
+              Spherical harmonic model of the daily geomagnetic variation at middle latitudes (Sq) and low latitudes (EEJ) (<a target="_blank" href="https://earth.esa.int/web/guest/missions/esa-eo-missions/swarm/data-handbook/level-2-product-definitions#MIO_SHA_2D">MIO_SHA_2D primary and secondary field</a>)
             </li>
           </ul>
 


### PR DESCRIPTION
Key features:
- changing from the deprecated `CHAOS-6-*` to `CHAOS-*` model ids
- implementing automated saved state migration (translation of model ids)
- changing the model descriptions