### PR TITLE
graphly.js update

### DIFF
--- a/app/scripts/util.js
+++ b/app/scripts/util.js
@@ -339,6 +339,8 @@ var savePrameterStatus = function (globals) {
         }
       } else if (innerpk === 'colorscale') {
         parC.colorscale = uomSet[pk].colorscale;
+      } else if (innerpk === 'logarithmic') {
+        parC.logarithmic = uomSet[pk].logarithmic;
       }
     }
     if (!_.isEmpty(parC)) {

--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
     "canvas-toBlob.js": "eligrey/canvas-toBlob.js",
     "Blob.js": "eligrey/Blob.js",
     "filepond": "pqina/filepond#^2.0.1",
-    "graphly": "eox-a/graphly#f2c4312ef9cb5ccf6927ba7f8925c9367f213084",
+    "graphly": "eox-a/graphly#41f5f767e52cd091797b01dc4dda4835c8aa1f88",
     "msgpack-lite": "^0.1.26",
     "choices.js": "~3.0.4"
   },

--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
     "canvas-toBlob.js": "eligrey/canvas-toBlob.js",
     "Blob.js": "eligrey/Blob.js",
     "filepond": "pqina/filepond#^2.0.1",
-    "graphly": "eox-a/graphly#41f5f767e52cd091797b01dc4dda4835c8aa1f88",
+    "graphly": "eox-a/graphly#f1f41974dfbacc3c414c83441e241d5c451fab38",
     "msgpack-lite": "^0.1.26",
     "choices.js": "~3.0.4"
   },

--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
     "canvas-toBlob.js": "eligrey/canvas-toBlob.js",
     "Blob.js": "eligrey/Blob.js",
     "filepond": "pqina/filepond#^2.0.1",
-    "graphly": "eox-a/graphly#f1f41974dfbacc3c414c83441e241d5c451fab38",
+    "graphly": "eox-a/graphly#e40bb45c9feac4126f91d76a7324d91fc2f09998",
     "msgpack-lite": "^0.1.26",
     "choices.js": "~3.0.4"
   },


### PR DESCRIPTION
Key features:
- Fixing image export (#410)
- porting log color scale from VfA