### PR TITLE
production release (VirES v3.6.0)

### DIFF
--- a/app/scripts/config.json
+++ b/app/scripts/config.json
@@ -264,7 +264,7 @@
             "views": [{
                 "id": "s2cloudless",
                 "protocol": "WMTS",
-                "urlTemplate": "https://{s}.s2maps-tiles.eu/wmts/?service=WMTS&version=1.0.0&request=GetTile&tilematrix={TileMatrix}&layer=s2cloudless-2018&style={Style}&tilerow={TileRow}&tilecol={TileCol}&tilematrixset={TileMatrixSet}&format=image%2Fjpg",
+                "urlTemplate": "https://{s}.s2maps-tiles.eu/wmts/?service=WMTS&version=1.0.0&request=GetTile&tilematrix={TileMatrix}&layer=s2cloudless-2020&style={Style}&tilerow={TileRow}&tilecol={TileCol}&tilematrixset={TileMatrixSet}&format=image%2Fjpg",
                 "subdomains": "abcdef",
                 "urls": [
                     "//a.tiles.maps.eox.at/wmts/",
@@ -283,7 +283,7 @@
                 "isphericalMercator": false,
                 "wrapDateLine": true,
                 "zoomOffset": 0,
-                "attribution": "Sentinel-2 cloudless - <a href=\"https://s2maps.eu\" target=\"_blank\">https://s2maps.eu</a> by <a href=\"https://eox.at\" target=\"_blank\">EOX IT Services GmbH</a> (Contains modified Copernicus Sentinel data 2016 & 2017)"
+                "attribution": "Sentinel-2 cloudless - <a href=\"https://s2maps.eu\" target=\"_blank\">https://s2maps.eu</a> by <a href=\"https://eox.at\" target=\"_blank\">EOX IT Services GmbH</a> (Contains modified Copernicus Sentinel data 2020)"
             }, {
                 "id": "s2cloudless",
                 "protocol": "WMS",

--- a/app/scripts/globals.js
+++ b/app/scripts/globals.js
@@ -27,8 +27,11 @@ define(
     });
 
     return {
-      version: "3.5.0",
-      supportedVersions: ["3.5.0", "3.4.0", "3.3.0", "3.2.0", "3.1.3", "3.1.2", "3.1.1", "3.1.0"],
+      version: "3.6.0",
+      supportedVersions: [
+        "3.6.0",
+        "3.5.0", "3.4.0", "3.3.0", "3.2.0", "3.1.3", "3.1.2", "3.1.1", "3.1.0"
+      ],
       objects: new ObjectStore(),
       selections: new ObjectStore(),
       baseLayers: new Backbone.Collection(),

--- a/app/scripts/init.js
+++ b/app/scripts/init.js
@@ -4,7 +4,7 @@
     var root = this;
 
     root.require.config({
-        urlArgs: 'bust=v3.5.0',
+        urlArgs: 'bust=v3.6.0',
 
         waitSeconds: 120,
         /* starting point for application */

--- a/app/templates/Info.hbs
+++ b/app/templates/Info.hbs
@@ -62,14 +62,42 @@
                Aurora oval boundaries derived from the Field-Aligned Currents data
                (<a target="_blank" href="https://earth.esa.int/eogateway/activities/swarm-aebs">AOBxFAC_2F</a>)
             </li>
+            <li style="list-style-type: circle;">
+               Mid-latitude ionospheric trough (MIT) boundaries and minima based on the Langmuir probe electron density and temperature measurements
+               (<a target="_blank" href="https://earth.esa.int/eogateway/activities/plasmapause-related-boundaries-in-the-topside-ionosphere-as-derived-from-swarm-measurements">MITx_LP_2F</a>),
+               accessible via the <a target="_blank" href="https://viresclient.readthedocs.io/en/latest/available_parameters.html#collections">Python client</a>.
+            </li>
+            <li style="list-style-type: circle;">
+               Mid-latitude ionospheric trough (MIT) boundaries and minima derived from the GPS TEC estimate
+               (<a target="_blank" href="https://earth.esa.int/eogateway/activities/plasmapause-related-boundaries-in-the-topside-ionosphere-as-derived-from-swarm-measurements">MITxTEC_2F</a>),
+               accessible via the <a target="_blank" href="https://viresclient.readthedocs.io/en/latest/available_parameters.html#collections">Python client</a>.
+            </li>
+            <li style="list-style-type: circle;">
+               Midnight plasma-pause index (PPI) and the associated SSFAC boundaries
+               (<a target="_blank" href="https://earth.esa.int/eogateway/activities/plasmapause-related-boundaries-in-the-topside-ionosphere-as-derived-from-swarm-measurements">PPIxFAC_2F</a>),
+               accessible via the <a target="_blank" href="https://viresclient.readthedocs.io/en/latest/available_parameters.html#collections">Python client</a>.
+            </li>
+            <li style="list-style-type: circle;">
+               Swarm spacecrafts' positions (<a target="_blank" href="https://earth.esa.int/web/guest/missions/esa-eo-missions/swarm/data-handbook/level-2-product-definitions#MODx_SC_1B">MODx_SC_1B</a>)
+            </li>
           </ul>
 
+          <p>The VirES API also provides access to:</a>
+          <ul>
+            <li style="list-style-type: circle;">
+              Hourly, 1 minute and 1 second ground magnetic observatory data (AUX_OBS) from
+              <a target="_blank" href="https://intermagnet.org/index-eng.php">INTERMAGNET</a> and
+              <a target="_blank" href="http://www.wdc.bgs.ac.uk/">WDC</a>
+            </li>
+            <li style="list-style-type: circle;">
+              1 and 4 months Virtual Observatory data (VOBS) from the
+              <a href="https://www.space.dtu.dk/english/research/projects/project-descriptions/geomagnetic-virtual-observatories" target="_blank">GVO project</a>.
+            </li>
+            <li style="list-style-type: circle;">
+              Vector magnetic field measurements acquired by the CryoSat-2, GRACE and GRACE-FO missions.
+            </li>
+          </ul>
           <p>
-            The VirES API also provides access to the hourly, 1 minute and 1 second ground magnetic observatory data (AUX_OBS) from
-            <a target="_blank" href="https://intermagnet.org/index-eng.php">INTERMAGNET</a> and
-            <a target="_blank" href="http://www.wdc.bgs.ac.uk/">WDC</a>,
-            as well as, the 1 and 4 months Virtual Observatory data (VOBS) from the
-            <a href="https://www.space.dtu.dk/english/research/projects/project-descriptions/geomagnetic-virtual-observatories" target="_blank">GVO project</a>.
             These datasets can be accessed with the
             <a target="_blank" href="https://viresclient.readthedocs.io/en/latest/available_parameters.html#collections">VirES Python client</a>,
             readily available in <a target="_blank" href="https://vre.vires.services">VRE</a>.


### PR DESCRIPTION
Key features:
- reading orbits from MODx_SC_1B products

related to https://github.com/ESA-VirES/VirES-Server/pull/170