### PR TITLE
Hotfix: changing CHAOS-7 to CHAOS-8.

### DIFF
--- a/app/scripts/config.json
+++ b/app/scripts/config.json
@@ -200,18 +200,18 @@
             },
             {
                 "id": "CHAOS",
-                "name": "CHAOS-7 (complete)",
+                "name": "CHAOS-8 (Core + Static + MMA)",
                 "blockDegreeSelection": true,
                 "excludes": ["CHAOS-Core", "CHAOS-Static", "CHAOS-MMA", "CHAOS-MMA-Primary", "CHAOS-MMA-Secondary"]
             },
             {
                 "id": "CHAOS-Core",
-                "name": "CHAOS-7 Core",
+                "name": "CHAOS-8 Core",
                 "excludes": ["CHAOS"]
             },
             {
                 "id": "CHAOS-Static",
-                "name": "CHAOS-7 Crust",
+                "name": "CHAOS-8 Crust",
                 "excludes": ["CHAOS"]
             },
             {

--- a/app/templates/Info.hbs
+++ b/app/templates/Info.hbs
@@ -164,7 +164,7 @@
               13th generation of the International Geomagnetic Reference Field (<a target="_blank" href="https://earth-planets-space.springeropen.com/articles/10.1186/s40623-020-01288-x">IGRF 13</a>) released in December 2019 by the International Association of Geomagnetism and Aeronomy
             </li>
             <li style="list-style-type: circle;">
-              The latest version of the CHAOS high resolution geomagnetic field model derived from Swarm, CHAMP, Ørsted, SAC-C and CryoSat-2 satellite magnetic data along with ground observatory data (<a target="_blank" href="https://spacecenter.dk/files/magnetic-models/CHAOS-7/">CHAOS-7</a>)
+              The latest version of the CHAOS high resolution geomagnetic field model derived from Swarm, MSS-1, CSES, CryoSat-2, CHAMP, SAC-C, and Ørsted satellite magnetic data along with ground observatory data (<a target="_blank" href="https://spacecenter.dk/files/magnetic-models/CHAOS-8/">CHAOS-8</a>)
             </li>
             <li style="list-style-type: circle;">
               Spherical harmonic model of the main (core) field and its temporal variation (<a target="_blank" href="https://swarmhandbook.earth.esa.int/catalogue/SW_MCO_SHA_2C">MCO_SHA_2C</a>)


### PR DESCRIPTION
Changing reference and labels from CHAOS-7 to the new CHAOS-8 model.